### PR TITLE
Refactor/optimizes the Docker image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,9 @@ SHELL ["/bin/bash", "-c"]
 WORKDIR /dev_ws/python_simple_mppi
 COPY . /dev_ws/python_simple_mppi
 
-RUN apt-get update
-RUN apt install -y ffmpeg nano
+RUN apt update \
+    && apt install -y ffmpeg nano \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN uv sync

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,13 +4,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 SHELL ["/bin/bash", "-c"]
 
-WORKDIR /dev_ws/
+WORKDIR /dev_ws/python_simple_mppi
+COPY . /dev_ws/python_simple_mppi
 
 RUN apt-get update
-RUN apt install -y git ffmpeg nano
+RUN apt install -y ffmpeg nano
 
-RUN git clone https://github.com/MizuhoAOKI/python_simple_mppi.git
-WORKDIR /dev_ws/python_simple_mppi
 RUN uv sync
-
-WORKDIR /dev_ws/python_simple_mppi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,4 +12,4 @@ RUN apt update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN uv sync
+RUN uv sync --no-cache


### PR DESCRIPTION
## what's changed
This PR optimizes the Docker image size to improve build efficiency and reduce storage/network costs.

By clearing the cache and disabling unnecessary clones during the Dockerfile build process, the image size was reduced by approximately **170MB**.

* **Cleared `apt` and `uv` caches** to reduce layer size.
* **Removed `git` installation** to keep the image lightweight.
* **Switched from `git clone` to `COPY`** for the working directory. 
  * This allows the inclusion of local custom libraries.

| Image Tag | Size | Status |
| :--- | :--- | :--- |
| `dev_mppi:v1.0` | 1.24 GB | Baseline |
| `dev_mppi:v1.1` | 1.07 GB | **Optimized (-170 MB)** |