### PR TITLE
Feature/docker compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ uv sync
     cd <path to your workspace>/python_simple_mppi
     docker compose run --rm dev
     ```
+    This command will automatically build the Docker image if needed.
     Once the container starts, any changes made in the local repository on the host will be reflected inside the container, and vice versa.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -57,16 +57,10 @@ uv sync
     git clone https://github.com/MizuhoAOKI/python_simple_mppi.git
     ```
 
-1. Run for the first time setup to build the docker image. Building the image might take a few minutes.
+1. Run setup to build the docker image, launch the docker container and get into the bash inside. Building the image might take a few minutes.
     ```
     cd <path to your workspace>/python_simple_mppi
-    docker build -t dev_mppi:v1.0 -f docker/Dockerfile .
-    ```
-
-1. Launch the docker container and get into the bash inside.
-    ```
-    cd <path to your workspace>/python_simple_mppi
-    docker run -it -v .:/dev_ws/python_simple_mppi --name dev_mppi_container dev_mppi:v1.0 bash
+    docker compose run --rm dev
     ```
     Once the container starts, any changes made in the local repository on the host will be reflected inside the container, and vice versa.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     container_name: dev_mppi_container
-    image: dev_mppi:v1.0
+    image: dev_mppi:v1.1
     volumes:
       - .:/dev_ws/python_simple_mppi
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,5 @@ services:
     image: dev_mppi:v1.1
     volumes:
       - .:/dev_ws/python_simple_mppi
-    environment:
-      - UV_PROJECT_ENVIRONMENT=/uv_venv
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,7 @@ services:
     image: dev_mppi:v1.0
     volumes:
       - .:/dev_ws/python_simple_mppi
+    environment:
+      - UV_PROJECT_ENVIRONMENT=/uv_venv
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: dev_mppi_container
+    image: dev_mppi:v1.0
+    volumes:
+      - .:/dev_ws/python_simple_mppi
+    stdin_open: true
+    tty: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 SHELL ["/bin/bash", "-c"]
 
+# Set uv environment variables for production
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+ENV UV_COMPILE_BYTECODE=0
+ENV UV_LINK_MODE=hardlink
+
 WORKDIR /dev_ws/python_simple_mppi
 COPY . /dev_ws/python_simple_mppi
 


### PR DESCRIPTION
## what's changed
This PR supports Docker compose to improve build and run container processes.
By setting the virtualenv path to `/opt/venv`, I resolved the issue where `uv virtualenv` was copied to the host when the workspace was mounted.

* Supports Docker compose
* Change uv virtualenv path from `/dev_ws/python_simple_mppi/.venv` to `/opt/venv`
  * This prevents `.venv` from being created in the host machine's workspace during mounting, keeping the host environment clean.
* Change README.md

### Changes in the Docker startup process
#### Before
```
# First, explicit Docker image build is required.
docker build -t dev_mppi:v1.1 -f docker/Dockerfile .
docker run -it -v .:/dev_ws/python_simple_mppi --name dev_mppi_container dev_mppi:v1.1 bash
```

#### After
```
# just one line
docker compose run --rm dev
```